### PR TITLE
새로운 게시글을 생성하는 엔드포인트 구현 완료

### DIFF
--- a/src/main/java/com/hyunsb/wanted/_core/error/ErrorMessage.java
+++ b/src/main/java/com/hyunsb/wanted/_core/error/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.hyunsb.wanted._core.error;
+
+public class ErrorMessage {
+
+    public static final String INVALID_EMAIL_FORMAT = "유효하지 않은 이메일 형식입니다.";
+    public static final String INVALID_PASSWORD_LENGTH = "비밀번호는 8자 이상이어야 합니다.";
+    public static final String USER_NOT_FOUND = "아이디와 비밀번호를 다시 확인해주세요.";
+
+    public static final String TOKEN_UN_AUTHORIZED = "토큰 인증에 실패하였습니다.";
+    public static final String TOKEN_EXPIRED = "토큰이 만료되었습니다.";
+    public static final String TOKEN_VERIFICATION_FAILED = "올바른 토큰이 아닙니다.";
+
+    public static final String INVALID_USER = "유효하지 않은 회원 정보입니다.";
+}

--- a/src/main/java/com/hyunsb/wanted/_core/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/hyunsb/wanted/_core/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.hyunsb.wanted._core.error;
 
+import com.hyunsb.wanted._core.error.exception.InternalServerErrorException;
 import com.hyunsb.wanted._core.error.exception.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<String> validationExceptionHandler(UnauthorizedException exception) {
+    public ResponseEntity<String> UnauthorizedExceptionHandler(UnauthorizedException exception) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(InternalServerErrorException.class)
+    public ResponseEntity<String> InternalServerErrorExceptionHandler(InternalServerErrorException exception) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exception.getMessage());
     }
 }

--- a/src/main/java/com/hyunsb/wanted/_core/error/exception/BoardSaveFailureException.java
+++ b/src/main/java/com/hyunsb/wanted/_core/error/exception/BoardSaveFailureException.java
@@ -1,0 +1,11 @@
+package com.hyunsb.wanted._core.error.exception;
+
+public class BoardSaveFailureException extends InternalServerErrorException {
+
+    public BoardSaveFailureException() {
+    }
+
+    public BoardSaveFailureException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/_core/error/exception/ErrorMessage.java
+++ b/src/main/java/com/hyunsb/wanted/_core/error/exception/ErrorMessage.java
@@ -1,8 +1,0 @@
-package com.hyunsb.wanted._core.error.exception;
-
-public class ErrorMessage {
-
-    public static final String INVALID_EMAIL_FORMAT = "유효하지 않은 이메일 형식입니다.";
-    public static final String INVALID_PASSWORD_LENGTH = "비밀번호는 8자 이상이어야 합니다.";
-    public static final String USER_NOT_FOUND = "아이디와 비밀번호를 다시 확인해주세요.";
-}

--- a/src/main/java/com/hyunsb/wanted/_core/error/exception/InternalServerErrorException.java
+++ b/src/main/java/com/hyunsb/wanted/_core/error/exception/InternalServerErrorException.java
@@ -1,0 +1,11 @@
+package com.hyunsb.wanted._core.error.exception;
+
+public class InternalServerErrorException extends RuntimeException {
+
+    public InternalServerErrorException() {
+    }
+
+    public InternalServerErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hyunsb/wanted/_core/security/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.hyunsb.wanted._core.security;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.hyunsb.wanted._core.error.ErrorMessage;
+import com.hyunsb.wanted._core.util.FilterResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtProvider jwtProvider) {
+        super(authenticationManager);
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = request.getHeader(JwtProvider.HEADER);
+
+        if (token == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            DecodedJWT decodedJWT = jwtProvider.verify(token);
+            Long userId = getUserIdFromToken(decodedJWT);
+
+            request.setAttribute(JwtProvider.REQUEST, userId);
+            chain.doFilter(request, response);
+
+        } catch (SignatureVerificationException sve) {
+            FilterResponse.unAuthorized(response, ErrorMessage.TOKEN_UN_AUTHORIZED);
+        } catch (TokenExpiredException tee) {
+            FilterResponse.unAuthorized(response, ErrorMessage.TOKEN_EXPIRED);
+        } catch (JWTDecodeException exception) {
+            FilterResponse.unAuthorized(response, ErrorMessage.TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private Long getUserIdFromToken(DecodedJWT decodedJWT) {
+        return decodedJWT.getClaim("id").asLong();
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/_core/security/JwtProvider.java
+++ b/src/main/java/com/hyunsb/wanted/_core/security/JwtProvider.java
@@ -9,19 +9,18 @@ import com.hyunsb.wanted.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.util.Date;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
 public class JwtProvider {
 
     public static final Long EXP = 1000L * 60 * 60;
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String HEADER = "Authorization";
+    public static final String REQUEST = "userId";
 
     private final Environment environment;
     private String key;
@@ -45,9 +44,13 @@ public class JwtProvider {
 
     public DecodedJWT verify(String jwt) throws SignatureVerificationException, TokenExpiredException {
         log.info("JWT verify: " + jwt);
-        String origin = jwt.replace(JwtProvider.TOKEN_PREFIX, "");
+        String origin = getOriginalJWT(jwt);
         return JWT.require(Algorithm.HMAC512(key))
                 .build()
                 .verify(origin);
+    }
+
+    private String getOriginalJWT(String jwt) {
+        return jwt.replace(JwtProvider.TOKEN_PREFIX, "");
     }
 }

--- a/src/main/java/com/hyunsb/wanted/_core/security/SecurityConfig.java
+++ b/src/main/java/com/hyunsb/wanted/_core/security/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.hyunsb.wanted._core.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -12,8 +15,18 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtProvider jwtProvider(Environment environment) {
+        return new JwtProvider(environment);
     }
 
     @Bean

--- a/src/main/java/com/hyunsb/wanted/_core/util/FilterResponse.java
+++ b/src/main/java/com/hyunsb/wanted/_core/util/FilterResponse.java
@@ -1,0 +1,38 @@
+package com.hyunsb.wanted._core.util;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FilterResponse {
+
+    private static final ObjectMapper OBJECT_MAPPER;
+    private static final String CONTENT_TYPE;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper();
+        CONTENT_TYPE = "application/json; charset=utf-8";
+    }
+
+    public static void unAuthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(CONTENT_TYPE);
+
+        String responseBody = OBJECT_MAPPER.writeValueAsString(message);
+        response.getWriter().println(responseBody);
+    }
+
+    public static void forbidden(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(CONTENT_TYPE);
+
+        String responseBody = OBJECT_MAPPER.writeValueAsString(message);
+        response.getWriter().println(responseBody);
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/board/Board.java
+++ b/src/main/java/com/hyunsb/wanted/board/Board.java
@@ -1,0 +1,31 @@
+package com.hyunsb.wanted.board;
+
+import com.hyunsb.wanted.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "board_tb")
+@Entity
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false)
+    @Lob
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/hyunsb/wanted/board/BoardController.java
+++ b/src/main/java/com/hyunsb/wanted/board/BoardController.java
@@ -1,0 +1,32 @@
+package com.hyunsb.wanted.board;
+
+import com.hyunsb.wanted._core.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping("/board")
+    public ResponseEntity<Object> save(
+            @RequestBody BoardRequest.SaveDTO saveDTO,
+            HttpServletRequest request) {
+        log.info("POST /board : " + saveDTO);
+
+        Long userId = (Long) request.getAttribute(JwtProvider.REQUEST);
+        boardService.save(saveDTO, userId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/board/BoardRepository.java
+++ b/src/main/java/com/hyunsb/wanted/board/BoardRepository.java
@@ -1,0 +1,6 @@
+package com.hyunsb.wanted.board;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/hyunsb/wanted/board/BoardRequest.java
+++ b/src/main/java/com/hyunsb/wanted/board/BoardRequest.java
@@ -1,0 +1,27 @@
+package com.hyunsb.wanted.board;
+
+import com.hyunsb.wanted.user.User;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardRequest {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    @Getter
+    @Builder
+    public static class SaveDTO {
+
+        private String title;
+        private String content;
+
+        public Board toEntityWith(User user) {
+            return Board.builder()
+                    .title(title)
+                    .content(content)
+                    .user(user)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/board/BoardService.java
+++ b/src/main/java/com/hyunsb/wanted/board/BoardService.java
@@ -1,0 +1,31 @@
+package com.hyunsb.wanted.board;
+
+import com.hyunsb.wanted._core.error.exception.BoardSaveFailureException;
+import com.hyunsb.wanted._core.error.ErrorMessage;
+import com.hyunsb.wanted.user.User;
+import com.hyunsb.wanted.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void save(BoardRequest.SaveDTO saveDTO, Long userId) {
+        userRepository.findById(userId).orElseThrow(() ->
+                new BoardSaveFailureException(ErrorMessage.INVALID_USER));
+
+        Board board = getBoardValueOf(saveDTO, userId);
+        boardRepository.save(board);
+    }
+
+    private Board getBoardValueOf(BoardRequest.SaveDTO saveDTO, Long userId) {
+        User user = User.builder().id(userId).build();
+        return saveDTO.toEntityWith(user);
+    }
+}

--- a/src/main/java/com/hyunsb/wanted/user/UserRequest.java
+++ b/src/main/java/com/hyunsb/wanted/user/UserRequest.java
@@ -1,6 +1,6 @@
 package com.hyunsb.wanted.user;
 
-import com.hyunsb.wanted._core.error.exception.ErrorMessage;
+import com.hyunsb.wanted._core.error.ErrorMessage;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 

--- a/src/main/java/com/hyunsb/wanted/user/UserService.java
+++ b/src/main/java/com/hyunsb/wanted/user/UserService.java
@@ -1,6 +1,6 @@
 package com.hyunsb.wanted.user;
 
-import com.hyunsb.wanted._core.error.exception.ErrorMessage;
+import com.hyunsb.wanted._core.error.ErrorMessage;
 import com.hyunsb.wanted._core.error.exception.UserNotFoundException;
 import com.hyunsb.wanted._core.security.JwtProvider;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/hyunsb/wanted/board/BoardControllerTest.java
+++ b/src/test/java/com/hyunsb/wanted/board/BoardControllerTest.java
@@ -1,0 +1,70 @@
+package com.hyunsb.wanted.board;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyunsb.wanted._core.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@WebMvcTest(controllers = BoardController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+        })
+class BoardControllerTest {
+
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BoardService boardService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Nested
+    @DisplayName("게시글 생성 컨트롤러 단위 테스트")
+    class Save {
+
+        @DisplayName("성공")
+        @Test
+        @WithMockUser
+        void success_Test() throws Exception {
+            // Given
+            String uri = "/board";
+            String title = "테스트용 게시글 제목";
+            String content = "테스트용 게시글 내용";
+
+            BoardRequest.SaveDTO saveDTO =
+                    BoardRequest.SaveDTO.builder()
+                            .title(title)
+                            .content(content)
+                            .build();
+
+            // When
+            // Then
+            mockMvc.perform(MockMvcRequestBuilders.post(uri)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
+                            .content(objectMapper.writeValueAsString(saveDTO)))
+                    .andExpect(MockMvcResultMatchers.status().isCreated());
+        }
+    }
+}

--- a/src/test/java/com/hyunsb/wanted/board/BoardIntegrationTest.java
+++ b/src/test/java/com/hyunsb/wanted/board/BoardIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.hyunsb.wanted.board;
+
+import com.hyunsb.wanted._core.error.exception.BoardSaveFailureException;
+import com.hyunsb.wanted.user.User;
+import com.hyunsb.wanted.user.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class BoardIntegrationTest {
+
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .password("password")
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Nested
+    @DisplayName("게시글 생성 통합 테스트")
+    class Save {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() {
+            // Given
+
+            Long userId = 1L;
+            BoardRequest.SaveDTO saveDTO =
+                    BoardRequest.SaveDTO.builder()
+                            .title("testTitle")
+                            .content("testContent")
+                            .build();
+
+            // When
+            // Then
+            boardService.save(saveDTO, userId);
+        }
+
+        @DisplayName("실패 - 유효하지 않은 userId")
+        @Test
+        void failure_Test_InvalidUserId() {
+            // Given
+            Long userId = 2L;
+            BoardRequest.SaveDTO saveDTO =
+                    BoardRequest.SaveDTO.builder()
+                            .title("testTitle")
+                            .content("testContent")
+                            .build();
+            // When
+            // Then
+            Assertions.assertThrows(BoardSaveFailureException.class,
+                    () -> boardService.save(saveDTO, userId));
+        }
+    }
+}

--- a/src/test/java/com/hyunsb/wanted/board/BoardServiceTest.java
+++ b/src/test/java/com/hyunsb/wanted/board/BoardServiceTest.java
@@ -1,0 +1,75 @@
+package com.hyunsb.wanted.board;
+
+import com.hyunsb.wanted._core.error.exception.BoardSaveFailureException;
+import com.hyunsb.wanted.user.User;
+import com.hyunsb.wanted.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private BoardService boardService;
+
+    @Nested
+    @DisplayName("게시글 생성 서비스 단위 테스트")
+    class Save {
+
+        @DisplayName("성공")
+        @Test
+        void success_Test() {
+            // Given
+            Mockito.when(userRepository.findById(ArgumentMatchers.anyLong()))
+                    .thenReturn(Optional.of(User.builder().id(1L).build()));
+
+            Mockito.when(boardRepository.save(ArgumentMatchers.any(Board.class)))
+                    .then(invocation -> invocation.getArgument(0));
+
+            Long userId = 1L;
+            BoardRequest.SaveDTO saveDTO =
+                    BoardRequest.SaveDTO.builder()
+                            .title("testTitle")
+                            .content("testContent")
+                            .build();
+            // When
+            // Then
+            boardService.save(saveDTO, userId);
+        }
+
+        @DisplayName("실패 - 유효하지 않은 userId")
+        @Test
+        void failure_Test_InvalidUserId() {
+            // Given
+            Mockito.when(userRepository.findById(ArgumentMatchers.anyLong()))
+                    .thenReturn(Optional.empty());
+
+            Long userId = 1L;
+            BoardRequest.SaveDTO saveDTO =
+                    BoardRequest.SaveDTO.builder()
+                            .title("testTitle")
+                            .content("testContent")
+                            .build();
+            // When
+            // Then
+            Assertions.assertThrows(BoardSaveFailureException.class,
+                    () -> boardService.save(saveDTO, userId));
+        }
+    }
+}


### PR DESCRIPTION
- 헤더에 로그인 시 발급받은 액세스토큰을 첨부하여 요청하도록 함.
- 간단하게 제목과 내용만 입력받음
- JWT 인증 필터에서 다이렉트로 유저 ID를 컨트롤러로 전달하도록 함. (세션 사용을 하지 않기 위함)
- #9 

resolved: #9 